### PR TITLE
Error handling

### DIFF
--- a/admin/routes/list.js
+++ b/admin/routes/list.js
@@ -14,6 +14,8 @@ var c = require(__base + '../shared-config/constants'),
 router.route('/')
 .get(function(req, res){
 
+    log('trace', 'list filter query', req.query);
+
     var page_title = 'Fatalaties List';
 
     renderView(req, res, 'fatality-list', {

--- a/shared-utils/http-get.js
+++ b/shared-utils/http-get.js
@@ -6,7 +6,7 @@ var __base = __base || '../',
 
 function get(o, cb){
 
-    log('trace', 'http-get request response');
+    log('trace', 'http-get request', o);
 
     var req = http.request(o, function(res) {
 
@@ -25,6 +25,8 @@ function get(o, cb){
 
         res.on('end', function() {
 
+            log('trace', 'http-get response end');
+
             if(status !== 200){
 
                 cb(status);
@@ -34,6 +36,11 @@ function get(o, cb){
                 cb(null, JSON.parse(output));
             }
         });
+    });
+
+    req.on('error', function(e) {
+        log('error', 'http-get request', e.message);
+        cb(e);
     });
 
     req.end();

--- a/shared-utils/query-filters.js
+++ b/shared-utils/query-filters.js
@@ -42,7 +42,7 @@ function queryFilter(filter) {
 
     if(filter.race){
         //TODO: Get rid of space in front of race
-        queryFilters['value.subject.race'] = ' ' + filter.race;
+        queryFilters['value.subject.race'] = filter.race;
     }
 
     if(filter.sex) {

--- a/shared-utils/render-view.js
+++ b/shared-utils/render-view.js
@@ -22,7 +22,7 @@ function renderView (req, res, component, data, locals) {
 
 	getView(req.lang, component, data, function(err, view) {
 
-		if(err){
+		if(err) {
 
 			log('error', 'could not get view', err);
 
@@ -30,15 +30,15 @@ function renderView (req, res, component, data, locals) {
         		'view' : "error"
     		});
 		
+		} else {
+
+			log('trace', 'got view, calling res.render()');
+
+			res.render('view', {
+				'view': view.html,
+				'locals': locals
+			});
 		}
-
-
-		log('trace', 'got view, calling res.render()');
-		
-		res.render('view', {
-        	'view' : view.html,
-        	'locals' : locals
-    	});
 	});
 }
 

--- a/shared-views/fatality-list-filter.js
+++ b/shared-views/fatality-list-filter.js
@@ -19,16 +19,19 @@ module.exports = function(d, cb) {
 
         httpGet(c.url.distinct + attribute, function(err, body){
 
-            if(err){
+            if(err) {
 
-                log('error', 'distinct sex error', err);
+                log('error', 'distinct ' + attribute + ' error', err);
                 deferred.reject(err);
-            }
 
-            deferred.resolve({
-                'values' : body
-            });
-        })
+            } else {
+
+                deferred.resolve({
+                    'values': body
+                });
+
+            }
+        });
 
         return deferred.promise;
     }
@@ -39,7 +42,7 @@ module.exports = function(d, cb) {
 
         log('trace', 'buildOptions', attributes);
 
-        var optionDefault = 'All '
+        var optionDefault = 'All ';
 
         if(name === 'sex'){
 
@@ -58,7 +61,7 @@ module.exports = function(d, cb) {
             value: null,
             selected: false,
             text: optionDefault
-        })
+        });
 
         _.each(attributes, function(value, i){
 
@@ -69,6 +72,7 @@ module.exports = function(d, cb) {
                     text: value
                 })
             }
+
         });
 
         return options;
@@ -100,5 +104,5 @@ module.exports = function(d, cb) {
         cb(null, filterModel);
     }
 
-    q.all([getDistinct('race'), getDistinct('sex'), getDistinct('cause')]).spread(fetchAllComplete);
+    q.all([getDistinct('race'), getDistinct('sex'), getDistinct('cause')]).spread(fetchAllComplete).catch(cb);
 };


### PR DESCRIPTION
I was getting a cryptic error when trying to access pages on the admin server. It turns out that there wasn't proper error handling in the `http-get` and the `fatality-list-filter` controllers.

This makes it so that accessing those pages won't crash the server, but it's not comprehensive. (The page just says "error"--it could stand to have a 500 message.)
